### PR TITLE
Set external-dns interval to 10m

### DIFF
--- a/addons/external-dns.yaml
+++ b/addons/external-dns.yaml
@@ -71,5 +71,6 @@ spec:
         - --provider=aws
         - --registry=txt
         - --txt-owner-id=${CLUSTER_NAME}
+        - --interval=10m # Default value (1m) causes "Rate Exceed" on Route 53 due to too many API call
         #- --domain-filter={{ dns_zone }}. # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         #- --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization


### PR DESCRIPTION
Too many minikubes hurts AWS route 53