### PR TITLE
Add the ability to override default ssh and api access cidr

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,14 +33,14 @@ resource "aws_security_group" "minikube" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.ssh_access_cidr}"]
   }
 
   ingress {
     from_port   = 6443
     to_port     = 6443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.api_access_cidr}"]
   }
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,13 @@ variable "ami_image_id" {
   description = "ID of the AMI image which should be used. If empty, the latest CentOS 7 image will be used. See README.md for AMI image requirements."
   default     = ""
 }
+
+variable "ssh_access_cidr" {
+    description = "CIDR from which SSH access is allowed"
+    default     = "0.0.0.0/0"
+}
+
+variable "api_access_cidr" {
+    description = "CIDR from which API access is allowed"
+    default     = "0.0.0.0/0"
+}


### PR DESCRIPTION
Hey @scholzj,

Love the project. Thanks for all of your hard work. I need the ability to override the default CIDRs for ssh and api access. It seemed like a simple enough tweak to submit.

Let me know if I can do anything to facilitate getting it merged.

Thanks,

Chris