### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ resource "aws_key_pair" "minikube_keypair" {
 # EC2 instance
 #####
 
-data "aws_ami" "centos7" {
+data "aws_ami" "centos8" {
   most_recent = true
   owners = ["aws-marketplace"]
 


### PR DESCRIPTION
updated from centos7 to 8

 Error: Your query returned no results. Please change your search criteria and try again.
│
│   with module.minikube.data.aws_ami.centos7,
│   on .terraform\modules\minikube\main.tf line 131, in data "aws_ami" "centos7":
│  131: data "aws_ami" "centos7" {
│
