### PR TITLE
Update CentOS 9 AMI

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,13 +128,13 @@ resource "aws_key_pair" "minikube_keypair" {
 # EC2 instance
 #####
 
-data "aws_ami" "centos7" {
+data "aws_ami" "centos9" {
   most_recent = true
-  owners = ["aws-marketplace"]
+  owners = ["125523088429"]
 
   filter {
-    name = "product-code"
-    values = ["aw0evgkw8e5c1q413zgy5pjce", "cvugziknvmxgqna9noibqnnsy"]
+    name   = "name"
+    values = ["CentOS Stream 9 x86_64*"]
   }
 
   filter {
@@ -156,7 +156,7 @@ resource "aws_instance" "minikube" {
   # Instance type - any of the c4 should do for now
   instance_type = var.aws_instance_type
 
-  ami = length(var.ami_image_id) > 0 ? var.ami_image_id : data.aws_ami.centos7.id
+  ami = length(var.ami_image_id) > 0 ? var.ami_image_id : data.aws_ami.centos9.id
 
   key_name = aws_key_pair.minikube_keypair.key_name
 

--- a/scripts/init-aws-minikube.sh
+++ b/scripts/init-aws-minikube.sh
@@ -191,16 +191,16 @@ kubectl label nodes --all node.kubernetes.io/exclude-from-external-load-balancer
 kubectl create clusterrolebinding admin-cluster-binding --clusterrole=cluster-admin --user=admin
 
 # Prepare the kubectl config file for download to client (IP address)
-export KUBECONFIG_OUTPUT=/home/centos/kubeconfig_ip
+export KUBECONFIG_OUTPUT=/home/ec2-user/kubeconfig_ip
 kubeadm kubeconfig user --client-name admin --config /tmp/kubeadm.yaml > $KUBECONFIG_OUTPUT
-chown centos:centos $KUBECONFIG_OUTPUT
+chown ec2-user:ec2-user $KUBECONFIG_OUTPUT
 chmod 0600 $KUBECONFIG_OUTPUT
 
-cp /home/centos/kubeconfig_ip /home/centos/kubeconfig
-sed -i "s/server: https:\/\/.*:6443/server: https:\/\/$IP_ADDRESS:6443/g" /home/centos/kubeconfig_ip
-sed -i "s/server: https:\/\/.*:6443/server: https:\/\/$DNS_NAME:6443/g" /home/centos/kubeconfig
-chown centos:centos /home/centos/kubeconfig
-chmod 0600 /home/centos/kubeconfig
+cp /home/ec2-user/kubeconfig_ip /home/ec2-user/kubeconfig
+sed -i "s/server: https:\/\/.*:6443/server: https:\/\/$IP_ADDRESS:6443/g" /home/ec2-user/kubeconfig_ip
+sed -i "s/server: https:\/\/.*:6443/server: https:\/\/$DNS_NAME:6443/g" /home/ec2-user/kubeconfig
+chown ec2-user:ec2-user /home/ec2-user/kubeconfig
+chmod 0600 /home/ec2-user/kubeconfig
 
 ########################################
 ########################################


### PR DESCRIPTION
I have upgraded the AMI from CentOS 7 to CentOS Stream 9. The AMI ID information is taken from the official [centos.org](https://www.centos.org/download/aws-images/) website,